### PR TITLE
記事ページのスタイル修正

### DIFF
--- a/components/article/BodyBlock.vue
+++ b/components/article/BodyBlock.vue
@@ -53,7 +53,7 @@ onBeforeUnmount(() => {
 /* applyの使用については議論があるが、統一されたスタイルの適用ができるため使用している。 */
 
 .cms-content{
-  @apply flex flex-col  text-base leading-8;
+  @apply flex flex-col  text-base;
 }
 
 .cms-content .img-wrapper{

--- a/components/article/BodyBlock.vue
+++ b/components/article/BodyBlock.vue
@@ -69,7 +69,7 @@ onBeforeUnmount(() => {
   }
 
 .cms-content ul{
-  @apply ml-4 my-4;
+  @apply md:ml-4 ml-1 my-4;
 }
 .cms-content li{
   @apply flex justify-start items-center;
@@ -79,7 +79,7 @@ onBeforeUnmount(() => {
   @apply block text-white text-lg font-extrabold mr-2
 }
 .cms-content a{
-  @apply underline font-semibold
+  @apply underline font-bold
 }
 .cms-content a::after{
   content: url("/assets/svg/open-in-new.svg");
@@ -101,11 +101,11 @@ onBeforeUnmount(() => {
 
 .cms-content h1,
 .cms-content h2{
-  @apply md:text-4xl text-3xl mt-8 mb-1;
+  @apply md:text-3xl text-2xl mt-10 mb-1 font-bold;
 }
 
 .cms-content h3{
-  @apply md:text-2xl text-2xl mt-6 mb-1;
+  @apply md:text-2xl text-xl mt-6 mb-1 font-bold;
 }
 
 </style>

--- a/components/article/BodyBlock.vue
+++ b/components/article/BodyBlock.vue
@@ -56,6 +56,9 @@ onBeforeUnmount(() => {
   @apply flex flex-col  text-base;
 }
 
+.cms-content strong{
+  @apply contents;
+}
 .cms-content .img-wrapper{
   @apply w-full  flex justify-center items-center my-4;
 }
@@ -69,14 +72,14 @@ onBeforeUnmount(() => {
   }
 
 .cms-content ul{
-  @apply md:ml-4 ml-1 my-4;
+  @apply md:ml-4 ml-0 my-4;
 }
 .cms-content li{
   @apply flex justify-start items-center;
 }
 .cms-content li::before{
   content: "//";
-  @apply block text-white text-lg font-extrabold mr-2
+  @apply self-start text-white text-xl font-extrabold mr-2
 }
 .cms-content a{
   @apply underline font-bold

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -86,7 +86,7 @@ module.exports = {
         ...vh
       },
       fontFamily: {
-        sans: ['Helvetica Neue', 'Helvetica', 'Hiragino Sans', 'Hiragino Kaku Gothic ProN', 'Arial', 'Yu Gothic', 'Meiryo', 'sans-serif', ...defaultTheme.fontFamily.sans]
+        sans: ['Avenir', 'Open Sans', 'Helvetica Neue', 'Helvetica,Arial', 'Verdana,Roboto', '游ゴシック', 'Yu Gothic', '游ゴシック体', 'YuGothic', 'ヒラギノ角ゴ Pro W3', 'Hiragino Kaku Gothic Pro', 'Meiryo UI', 'メイリオ', 'Meiryo', 'ＭＳ Ｐゴシック', 'MS PGothic', 'sans-serif', ...defaultTheme.fontFamily.sans]
       }
     },
     variants: {


### PR DESCRIPTION
- 行間が開いていたため初期値に戻した
- heading要素の太さと大きさを調整
- リストのbefore要素のいちが必ず上に来るよう修正